### PR TITLE
Restore compatibility with Cordova Android 4.0+

### DIFF
--- a/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/DonutMobileAccessibilityHelper.java
@@ -38,7 +38,12 @@ public class DonutMobileAccessibilityHelper extends
     @Override
     public void initialize(MobileAccessibility mobileAccessibility) {
         mMobileAccessibility = mobileAccessibility;
-        mWebView = (WebView) mobileAccessibility.webView;
+        try {
+          mWebView = (WebView) mobileAccessibility.webView;
+        } catch (ClassCastException ce) {   // cordova-android 4.0+
+          mWebView = (WebView) mobileAccessibility.webView.getView();
+        }
+
         mAccessibilityManager = (AccessibilityManager) mMobileAccessibility.cordova.getActivity().getSystemService(Context.ACCESSIBILITY_SERVICE);
     }
 

--- a/src/android/com/phonegap/plugin/mobileaccessibility/JellyBeanMobileAccessibilityHelper.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/JellyBeanMobileAccessibilityHelper.java
@@ -34,8 +34,14 @@ public class JellyBeanMobileAccessibilityHelper extends
 
     @Override
     public void initialize(MobileAccessibility mobileAccessibility) {
+        WebView view;
         super.initialize(mobileAccessibility);
-        mParent = ((WebView) mobileAccessibility.webView).getParentForAccessibility();
+        try {
+            view = (WebView) mobileAccessibility.webView;
+        } catch (ClassCastException ce) {   // cordova android 4.0+
+            view = (WebView) mobileAccessibility.webView.getView();
+        }
+        mParent = view.getParentForAccessibility();
     }
 
     @Override

--- a/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
@@ -133,9 +133,15 @@ public class MobileAccessibility extends CordovaPlugin {
             stop();
             cordova.getActivity().runOnUiThread(new Runnable() {
                 public void run() {
-                        ((WebView) webView).reload();
-                    }
-                });
+                  WebView view;
+                  try {
+                    view = (WebView) webView;
+                  } catch(ClassCastException ce) {  // cordova-android 4.0+
+                    view = (WebView) webView.getView();
+                  }
+                  view.reload();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Fixes #17 and #13.  The WebView object is now accessed via a `getView()` method call on `CordovaWebView` objects.