### PR TITLE
now compatible with cordova-ios 4.0.0 (fixes issue #26)

### DIFF
--- a/src/ios/CDVMobileAccessibility.m
+++ b/src/ios/CDVMobileAccessibility.m
@@ -180,7 +180,11 @@
     mFontScale = zoom/100;
     if (iOS7Delta)  {
         NSString *jsString = [[NSString alloc] initWithFormat:@"document.getElementsByTagName('body')[0].style.webkitTextSizeAdjust= '%f%%'", zoom];
+#ifdef __CORDOVA_4_0_0
+        [[self webViewEngine] evaluateJavaScript:jsString completionHandler:nil];
+#else
         [[self webView] stringByEvaluatingJavaScriptFromString:jsString];
+#endif
     }
 }
 


### PR DESCRIPTION
See issue #26. Was broken on cordova-ios 4.0.0; Modified CDVMobileAccessibility.m:183 to use new webViewEngine if Cordova 4.0.0.
Tested on iOS 9.2, cordova-ios 4.0.0; working.