### PR TITLE
(Android): Fix app crash when resuming from background

### DIFF
--- a/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
+++ b/src/android/com/phonegap/plugin/mobileaccessibility/MobileAccessibility.java
@@ -144,8 +144,11 @@ public class MobileAccessibility extends CordovaPlugin {
                     } catch(ClassCastException ce) {  // cordova-android 4.0+
                         try {   // cordova-android 4.0+
                             Method getView = webView.getClass().getMethod("getView");
-                            Method reload = getView.invoke(webView).getClass().getMethod("reload");
-                            reload.invoke(webView);
+                            Object aView = getView.invoke(webView);
+                            if (aView != null) {
+                                Method reload = aView.getClass().getMethod("reload");
+                                reload.invoke(aView);
+                            }
                         } catch (NoSuchMethodException e) {
                             e.printStackTrace();
                         } catch (InvocationTargetException e) {


### PR DESCRIPTION
 Resolves #40.

Stops this plugin causing apps to crash when:
- Talkback screenreader is off when the app is launched
- The app is paused in the background
- Talkback is turned on while the app is in the background
- The app is resumed from the background.